### PR TITLE
 ip/ip6tables 2019-001: use optimised iptables parameters

### DIFF
--- a/advisories/third-party/2019-001/block-low-mss/ip6tables.txt
+++ b/advisories/third-party/2019-001/block-low-mss/ip6tables.txt
@@ -1,2 +1,2 @@
 
-ip6tables -A INPUT -p tcp -m tcpmss --mss 1:500 -j DROP
+ip6tables -t raw -I PREROUTING -p tcp -m tcpmss --mss 1:500 -j DROP

--- a/advisories/third-party/2019-001/block-low-mss/iptables.txt
+++ b/advisories/third-party/2019-001/block-low-mss/iptables.txt
@@ -1,3 +1,3 @@
 
-iptables -A INPUT -p tcp -m tcpmss --mss 1:500 -j DROP
-ip6tables -A INPUT -p tcp -m tcpmss --mss 1:500 -j DROP
+iptables -t raw -I PREROUTING -p tcp -m tcpmss --mss 1:500 -j DROP
+ip6tables -t raw -I PREROUTING -p tcp -m tcpmss --mss 1:500 -j DROP


### PR DESCRIPTION
Prefer `-t raw -I PREROUTING` over `-A INPUT` for optimal performance.